### PR TITLE
Avoided crash when no 'celeryresults' exchange declared by Celery.

### DIFF
--- a/src/celery.erl
+++ b/src/celery.erl
@@ -281,6 +281,10 @@ publish(Payload, From, ReturnMethod, RequestId, State
     
 setup_reply_queue(#state{
         channel=Channel, reply_queue=Q, reply_queue_durable=ReplyQueueDurable}) ->
+    #'exchange.declare_ok'{} =
+        amqp_channel:call(Channel,
+            #'exchange.declare'{exchange = <<"celeryresults">>,
+                                durable = true}),
     #'queue.declare_ok'{} =
         amqp_channel:call(Channel,
                           #'queue.declare'{


### PR DESCRIPTION
When no 'celeryresults' exchange declared by Celery, the channel process would crash.
